### PR TITLE
fix: Include helpers directory in example OPA build commands

### DIFF
--- a/examples/claude-code/0_Welcome/setup.ps1
+++ b/examples/claude-code/0_Welcome/setup.ps1
@@ -62,9 +62,9 @@ Write-Host "✅ Example policies copied" -ForegroundColor Green
 
 Write-Host "✅ Builtins configured (protected_paths, git_pre_check, rulebook_security_guardrails)" -ForegroundColor Green
 
-# Compile policies to WASM (only Claude Code policies)
+# Compile policies to WASM (Claude Code policies + shared helpers)
 Write-Host "`nCompiling Claude Code policies to WASM..."
-opa build -t wasm -e cupcake/system/evaluate .cupcake/policies/claude/
+opa build -t wasm -e cupcake/system/evaluate .cupcake/policies/claude/ .cupcake/policies/helpers/
 if ($LASTEXITCODE -ne 0) {
     Write-Host "❌ Policy compilation failed" -ForegroundColor Red
     exit 1

--- a/examples/claude-code/0_Welcome/setup.sh
+++ b/examples/claude-code/0_Welcome/setup.sh
@@ -50,9 +50,9 @@ echo "✅ Example policies copied"
 # Builtins are now pre-configured in the base template
 echo "✅ Builtins configured (protected_paths, git_pre_check, rulebook_security_guardrails)"
 
-# Compile policies to WASM (only Claude Code policies)
+# Compile policies to WASM (Claude Code policies + shared helpers)
 echo "Compiling Claude Code policies to WASM..."
-opa build -t wasm -e cupcake/system/evaluate .cupcake/policies/claude/
+opa build -t wasm -e cupcake/system/evaluate .cupcake/policies/claude/ .cupcake/policies/helpers/
 echo "✅ Policies compiled to bundle.tar.gz"
 
 # Create Claude Code settings directory and hooks integration

--- a/examples/cursor/0_Welcome/setup.ps1
+++ b/examples/cursor/0_Welcome/setup.ps1
@@ -159,9 +159,9 @@ $fileProtectionPolicy | Out-File -FilePath ".cupcake\policies\cursor\file_protec
 
 Write-Host "✅ Cursor-specific policies created" -ForegroundColor Green
 
-# Compile policies to WASM (only Cursor policies)
+# Compile policies to WASM (Cursor policies + shared helpers)
 Write-Host "`nCompiling Cursor policies to WASM..."
-opa build -t wasm -e cupcake/system/evaluate .cupcake/policies/cursor/
+opa build -t wasm -e cupcake/system/evaluate .cupcake/policies/cursor/ .cupcake/policies/helpers/
 if ($LASTEXITCODE -ne 0) {
     Write-Host "❌ Policy compilation failed" -ForegroundColor Red
     exit 1

--- a/examples/cursor/0_Welcome/setup.sh
+++ b/examples/cursor/0_Welcome/setup.sh
@@ -49,9 +49,9 @@ echo "✅ Example policies copied (context_injection skipped - not supported by 
 # Builtins are now pre-configured in the base template
 echo "✅ Builtins configured (protected_paths, git_pre_check, rulebook_security_guardrails)"
 
-# Compile policies to WASM (only Cursor policies)
+# Compile policies to WASM (Cursor policies + shared helpers)
 echo "Compiling Cursor policies to WASM..."
-opa build -t wasm -e cupcake/system/evaluate .cupcake/policies/cursor/
+opa build -t wasm -e cupcake/system/evaluate .cupcake/policies/cursor/ .cupcake/policies/helpers/
 echo "✅ Policies compiled to bundle.tar.gz"
 
 # Create Claude Code settings directory and hooks integration


### PR DESCRIPTION
The recent refactoring introduced shared helper functions in .cupcake/policies/helpers/ to centralize command parsing and prevent bypass vulnerabilities. Example setup scripts were not updated to include this directory during policy compilation, causing "undefined function" errors.

Changes:
- Updated all example setup scripts (bash + PowerShell) to include .cupcake/policies/helpers/ in OPA build commands
- Both Claude Code and Cursor examples now compile correctly

This matches the engine's compilation behavior which automatically includes the helpers directory alongside harness-specific policies.

