### PR TITLE
Use uv over pip

### DIFF
--- a/examples/claude-code/0_Welcome/README.md
+++ b/examples/claude-code/0_Welcome/README.md
@@ -31,6 +31,7 @@ Before starting, ensure you have:
   - **Windows users**: Download `opa_windows_amd64.exe` and rename to `opa.exe`
 - **Claude Code** → AI coding assistant
 - **Docker** (optional) → For MCP database demo
+- [**uv**](https://docs.astral.sh/uv/) to run Python scripts
 
 _These are development requirements. The production software will manage these dependencies._
 

--- a/examples/claude-code/0_Welcome/mcp_setup.sh
+++ b/examples/claude-code/0_Welcome/mcp_setup.sh
@@ -12,17 +12,6 @@ else
     echo "✅ Docker is running"
 fi
 
-# Check for Python dependencies
-echo "Checking Python dependencies..."
-if ! python3 -c "import psycopg2" 2>/dev/null; then
-    echo "Installing psycopg2-binary for database connection..."
-    pip3 install psycopg2-binary || echo "Warning: Could not install psycopg2-binary"
-fi
-if ! python3 -c "import yaml" 2>/dev/null; then
-    echo "Installing PyYAML for configuration management..."
-    pip3 install pyyaml || echo "Warning: Could not install PyYAML"
-fi
-
 # Pull postgres-mcp Docker image if needed
 echo "Pulling postgres-mcp Docker image..."
 docker pull crystaldba/postgres-mcp || echo "Warning: Could not pull postgres-mcp image"
@@ -114,7 +103,7 @@ cat .cupcake/rulebook.yml
 # Add signal configuration to rulebook.yml
 echo "Configuring appointment time signal..."
 # Use Python to properly merge the signal into existing YAML
-python3 << 'EOF'
+uv run --with pyyaml python3 << 'EOF'
 import yaml
 
 # Read existing rulebook
@@ -140,7 +129,7 @@ if 'actions' in rulebook and rulebook['actions'] is None:
     rulebook['actions'] = {}
 
 rulebook['signals']['appointment_time_check'] = {
-    'command': 'python3 .cupcake/check_appointment_time.py'
+    'command': 'uv run --with psycopg2-binary python3 .cupcake/check_appointment_time.py'
 }
 
 # Write back the updated rulebook

--- a/examples/claude-code/0_Welcome/setup.ps1
+++ b/examples/claude-code/0_Welcome/setup.ps1
@@ -25,6 +25,16 @@ try {
     exit 1
 }
 
+# Check if OPA is installed
+try {
+    $uvVersion = uv --version 2>$null
+    Write-Host "✅ uv found: $uvVersion" -ForegroundColor Green
+} catch {
+    Write-Host "❌ uv not found in PATH. Please install OPA:" -ForegroundColor Red
+    Write-Host "   https://docs.astral.sh/uv/" -ForegroundColor Yellow
+    exit 1
+}
+
 # Build Cupcake binary
 Write-Host "`nBuilding Cupcake binary..."
 Push-Location ../../..

--- a/examples/claude-code/0_Welcome/setup.sh
+++ b/examples/claude-code/0_Welcome/setup.sh
@@ -22,6 +22,15 @@ else
     echo "✅ OPA found: $(opa version | head -n1)"
 fi
 
+# Check if uv is installed
+if ! command -v uv &> /dev/null; then
+    echo "❌ uv not found in PATH. Please install uv:"
+    echo "   https://docs.astral.sh/uv/"
+    exit 1
+else
+    echo "✅ uv found: $(uv --version)"
+fi
+
 # Build Cupcake binary
 echo "Building Cupcake binary..."
 cd ../../..


### PR DESCRIPTION
Many Linux distros do not support running pip install anymore, because it modifies things globally. It is also considered bad practice. Using uv will create temporary venvs for the few third party dependencies this example has.