### PR TITLE
chore: make documentation location not mandatory in issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -28,10 +28,8 @@ body:
     id: location
     attributes:
       label: Documentation Location
-      description: Where is the documentation issue? Provide a URL, file path, or section name.
-      placeholder: "https://docs.getcupcake.io/... or docs/getting-started/..."
-    validations:
-      required: true
+      description: If the issue is related to a certain page, provide a URL.
+      placeholder: "https://cupcake.eqtylab.io/"
 
   - type: textarea
     id: description


### PR DESCRIPTION
There may be docs issues that aren't on a specific page!

Making this more specific to give folks clear instructions what to do, but also making it optional so we don't get junk data.