### PR TITLE
ci: check code version against tag during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,16 @@ jobs:
       - name: Get version from tag
         id: get_version
         run: |
+          CODE_VERSION=$(grep -oP '^version = "\K[0-9]+\.[0-9]+\.[0-9]+' Cargo.toml)
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             VERSION="${{ github.event.inputs.tag }}"
           else
             VERSION="${GITHUB_REF#refs/tags/}"
+            if [[ "$VERSION" != "v$CODE_VERSION" ]]; then
+              echo "Error: Tag version ($VERSION) does not match version in Cargo.toml ($CODE_VERSION)."
+              echo "Update Cargo.toml and re-tag."
+              exit 1
+            fi
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Version: ${VERSION}"


### PR DESCRIPTION
- adds CI check that version built into cupcake-cli from Cargo.toml matches tag triggering the release

Right now if I install the latest version it installs version 0.5.1 but running `cupcake --version` gives `0.3.0`.
