### PR TITLE
feat(#100): python bindings

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -206,16 +206,48 @@ jobs:
           Move-Item opa.exe "C:\Windows\System32\opa.exe" -Force
           & opa version
 
-      - name: Install maturin and test dependencies
-        run: pip install maturin pytest pytest-asyncio
-
-      - name: Build Python bindings
+      - name: Create virtualenv and install dependencies (Unix)
+        if: runner.os != 'Windows'
         run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install maturin pytest pytest-asyncio
+
+      - name: Create virtualenv and install dependencies (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          python -m venv .venv
+          .venv\Scripts\Activate.ps1
+          pip install maturin pytest pytest-asyncio
+
+      - name: Build Python bindings (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          source .venv/bin/activate
           cd cupcake-py
           maturin develop --release
 
-      - name: Run Python tests
+      - name: Build Python bindings (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
         run: |
+          .venv\Scripts\Activate.ps1
+          cd cupcake-py
+          maturin develop --release
+
+      - name: Run Python tests (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          source .venv/bin/activate
+          cd cupcake-py
+          pytest tests/ -v
+
+      - name: Run Python tests (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          .venv\Scripts\Activate.ps1
           cd cupcake-py
           pytest tests/ -v
         env:

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -15,6 +15,8 @@ on:
       # Policy/fixture changes that affect tests
       - "fixtures/**"
       - "**.rego"
+      # Python binding changes
+      - "cupcake-py/**"
   workflow_dispatch:
 
 env:
@@ -161,6 +163,63 @@ jobs:
       - uses: actions/checkout@v4
       - uses: eqtylab-actions/install-nix-action@v31
       - run: nix build .#cupcake-cli -L
+
+  test-python:
+    name: Python Bindings (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [cupcake-ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install OPA (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/v1.7.1/opa_linux_amd64_static
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/v1.7.1/opa_darwin_amd64
+          fi
+          chmod +x opa
+          sudo mv opa /usr/local/bin/
+          opa version
+
+      - name: Install OPA (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/open-policy-agent/opa/releases/download/v1.7.1/opa_windows_amd64.exe" -OutFile "opa.exe"
+          Move-Item opa.exe "C:\Windows\System32\opa.exe" -Force
+          & opa version
+
+      - name: Install maturin and test dependencies
+        run: pip install maturin pytest pytest-asyncio
+
+      - name: Build Python bindings
+        run: |
+          cd cupcake-py
+          maturin develop --release
+
+      - name: Run Python tests
+        run: |
+          cd cupcake-py
+          pytest tests/ -v
+        env:
+          CI: true
 
   fmt:
     name: Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ on:
       # Policy/fixture changes that affect tests
       - "fixtures/**"
       - "**.rego"
+      # Python binding changes
+      - "cupcake-py/**"
   workflow_dispatch:
 
 env:
@@ -86,5 +88,47 @@ jobs:
       - name: Run doc-tests
         run: |
           cargo test --doc -j 1 -- --test-threads=1
+        env:
+          CI: true
+
+  test-python:
+    name: Python Bindings (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install OPA
+        run: |
+          curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/v1.7.1/opa_linux_amd64_static
+          chmod +x opa
+          sudo mv opa /usr/local/bin/
+          opa version
+
+      - name: Install maturin and test dependencies
+        run: pip install maturin pytest pytest-asyncio
+
+      - name: Build Python bindings
+        run: |
+          cd cupcake-py
+          maturin develop --release
+
+      - name: Run Python tests
+        run: |
+          cd cupcake-py
+          pytest tests/ -v
         env:
           CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,16 +118,21 @@ jobs:
           sudo mv opa /usr/local/bin/
           opa version
 
-      - name: Install maturin and test dependencies
-        run: pip install maturin pytest pytest-asyncio
+      - name: Create virtualenv and install dependencies
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install maturin pytest pytest-asyncio
 
       - name: Build Python bindings
         run: |
+          source .venv/bin/activate
           cd cupcake-py
           maturin develop --release
 
       - name: Run Python tests
         run: |
+          source .venv/bin/activate
           cd cupcake-py
           pytest tests/ -v
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.2",
  "wasmtime-internal-math",
 ]
 
@@ -483,7 +483,7 @@ dependencies = [
  "cranelift-codegen",
  "log",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.2",
 ]
 
 [[package]]
@@ -500,7 +500,7 @@ checksum = "2eee7a496dd66380082c9c5b6f2d5fa149cec0ec383feec5caf079ca2b3671c2"
 dependencies = [
  "cranelift-codegen",
  "libc",
- "target-lexicon",
+ "target-lexicon 0.13.2",
 ]
 
 [[package]]
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cupcake-cli"
-version = "0.3.0"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "cupcake-core"
-version = "0.3.0"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -665,8 +665,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cupcake-py"
+version = "0.5.2"
+dependencies = [
+ "anyhow",
+ "cupcake-core",
+ "pyo3",
+ "serde_json",
+]
+
+[[package]]
 name = "cupcake-ts"
-version = "0.3.0"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "cupcake-core",
@@ -1346,6 +1356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "insta"
 version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1622,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1957,6 +1985,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "938543690519c20c3a480d20a8efcc8e69abeb44093ab1df4e7c1f81f26c677a"
 dependencies = [
  "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+dependencies = [
+ "once_cell",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn 2.0.104",
 ]
@@ -2597,6 +2688,12 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
@@ -3008,6 +3105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3274,7 +3377,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.2",
  "trait-variant",
  "wasm-encoder 0.235.0",
  "wasmparser 0.235.0",
@@ -3316,7 +3419,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.2",
  "wasm-encoder 0.235.0",
  "wasmparser 0.235.0",
  "wasmprinter",
@@ -3392,7 +3495,7 @@ dependencies = [
  "object",
  "pulley-interpreter",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.2",
  "thiserror 2.0.14",
  "wasmparser 0.235.0",
  "wasmtime-environ",
@@ -3489,7 +3592,7 @@ dependencies = [
  "cranelift-codegen",
  "gimli",
  "object",
- "target-lexicon",
+ "target-lexicon 0.13.2",
  "wasmparser 0.235.0",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
@@ -3602,7 +3705,7 @@ dependencies = [
  "gimli",
  "regalloc2",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.2",
  "thiserror 2.0.14",
  "wasmparser 0.235.0",
  "wasmtime-environ",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # Core members that build reliably across all environments
 default-members = ["cupcake-core", "cupcake-cli"]
 # All members (including optional language bindings)
-members = ["cupcake-core", "cupcake-cli", "cupcake-ts"]
+members = ["cupcake-core", "cupcake-cli", "cupcake-ts", "cupcake-py"]
 resolver = "2"
 
 [workspace.package]

--- a/cupcake-py/Cargo.toml
+++ b/cupcake-py/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "cupcake-py"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Python bindings for Cupcake policy engine"
+
+[lib]
+name = "cupcake_native"
+crate-type = ["cdylib"]
+
+[dependencies]
+# Core library
+cupcake-core = { workspace = true }
+
+# PyO3
+pyo3 = { version = "0.23", features = ["extension-module"] }
+
+# Core dependencies
+serde_json = { workspace = true }
+anyhow = { workspace = true }

--- a/cupcake-py/README.md
+++ b/cupcake-py/README.md
@@ -1,0 +1,230 @@
+# cupcake (Python)
+
+Python bindings for the [Cupcake](https://cupcake.eqtylab.io) policy engine — governance and safety for AI coding agents.
+
+Built with [PyO3](https://pyo3.rs) + [maturin](https://www.maturin.rs), wrapping the same Rust `cupcake-core` engine used by the TypeScript bindings and the CLI.
+
+## Installation
+
+```bash
+pip install cupcake
+```
+
+Or build from source (see [Development](#development) below).
+
+## Quick Start
+
+### Async (recommended)
+
+```python
+from cupcake import Cupcake
+
+cupcake = Cupcake()
+await cupcake.init(".cupcake")
+
+decision = await cupcake.evaluate({
+    "hookEventName": "PreToolUse",
+    "tool_name": "Bash",
+    "command": "rm -rf /",
+})
+
+if "Deny" in decision:
+    print(f"Blocked: {decision['Deny']['reason']}")
+```
+
+### Sync (CLI scripts)
+
+```python
+from cupcake import Cupcake
+
+cupcake = Cupcake()
+cupcake.init_sync(".cupcake")
+
+decision = cupcake.evaluate_sync({
+    "hookEventName": "PreToolUse",
+    "tool_name": "Bash",
+    "command": "ls -la",
+})
+```
+
+### Module-level API (singleton)
+
+```python
+import cupcake
+
+await cupcake.init(".cupcake")
+decision = await cupcake.evaluate(event)
+```
+
+## API Reference
+
+### `Cupcake` class
+
+| Method | Description |
+|---|---|
+| `await init(path, harness)` | Initialize engine (async, non-blocking) |
+| `init_sync(path, harness)` | Initialize engine (sync, blocks thread) |
+| `await evaluate(event)` | Evaluate event (async, non-blocking) |
+| `evaluate_sync(event)` | Evaluate event (sync, blocks thread) |
+| `version` | Engine version string (property) |
+| `is_ready` | Whether engine is ready (property) |
+
+### Parameters
+
+- **path** — Path to project directory or `.cupcake` folder (default: `".cupcake"`)
+- **harness** — AI agent harness type: `"claude"`, `"cursor"`, `"factory"`, or `"opencode"` (default: `"claude"`)
+- **event** — Dict with hook event data (your policies define the schema)
+
+### Decision Format
+
+The engine returns a dict with the decision variant as key:
+
+```python
+# Allow
+{"Allow": {"context": ["Looks safe"]}}
+
+# Deny
+{"Deny": {"reason": "Destructive command blocked", "agent_messages": []}}
+
+# Ask
+{"Ask": {"reason": "Confirm before proceeding", "agent_messages": []}}
+
+# Modify
+{"Modify": {"reason": "Sanitized", "updated_input": {...}, "agent_messages": []}}
+```
+
+## Development
+
+### Prerequisites
+
+- **Rust toolchain** — Install via [rustup](https://rustup.rs/) (the workspace pins Rust 1.91.0 via `rust-toolchain.toml`)
+- **Python 3.9+** — CPython (PyPy is not supported by PyO3)
+- **OPA v1.7.1+** — Required for policy compilation. The bindings auto-download it, or install manually:
+  ```bash
+  # macOS
+  brew install opa
+
+  # Linux x86_64 (non-static build required for WASM support)
+  curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/v1.7.1/opa_linux_amd64
+  chmod +x opa && sudo mv opa /usr/local/bin/
+  ```
+- **maturin** — The Rust-to-Python build tool:
+  ```bash
+  pip install maturin
+  ```
+
+### Building from source
+
+```bash
+# Clone the cupcake repo (if you haven't already)
+git clone https://github.com/eqtylab/cupcake.git
+cd cupcake
+
+# Install maturin and test dependencies
+pip install maturin pytest pytest-asyncio
+
+# Build the native module in development mode (editable install)
+cd cupcake-py
+maturin develop --release
+
+# Verify it works
+python -c "from cupcake import Cupcake; print(Cupcake())"
+```
+
+### Using just (recommended)
+
+The workspace [justfile](../justfile) has convenience commands:
+
+```bash
+# Build Python bindings (creates venv, installs deps, builds)
+just build-python
+
+# Run Python tests
+just test-python
+
+# Build a distributable wheel
+just build-python-wheel
+
+# Run everything (Rust + TypeScript + Python)
+just test-all
+
+# Install all dev dependencies (Rust tools + Python venv)
+just install-dev
+```
+
+### Using Nix
+
+The `flake.nix` provides a dev shell with all dependencies and a `cupcake-py` package:
+
+```bash
+# Enter dev shell (has rust, python, maturin, pytest)
+nix develop
+
+# Build the Python wheel via Nix
+nix build .#cupcake-py
+```
+
+### Running tests
+
+```bash
+cd cupcake-py
+
+# Run all tests
+pytest tests/ -v
+
+# Run just the error/API tests (no engine needed)
+pytest tests/ -v -k "Error or NoInit or repr or version_before"
+```
+
+**Platform note:** OPA's static ARM64 Linux builds lack WASM compilation support. On ARM64, tests that require engine initialization will be automatically skipped. All tests pass on x86_64 (the CI target platform).
+
+### Building a wheel
+
+```bash
+cd cupcake-py
+
+# Build release wheel for current platform
+maturin build --release
+
+# Wheel is in ../target/wheels/
+ls ../target/wheels/cupcake-*.whl
+```
+
+## Architecture
+
+```
+cupcake-py/
+├── Cargo.toml              # Rust crate config (PyO3)
+├── pyproject.toml           # Python packaging (maturin backend)
+├── src/
+│   └── lib.rs              # PyO3 bindings → BindingEngine
+├── python/
+│   └── cupcake/
+│       ├── __init__.py      # Python API (class + module-level)
+│       ├── _installer.py    # OPA binary auto-installer
+│       ├── _native.pyi      # Type stubs for native module
+│       └── py.typed         # PEP 561 marker
+└── tests/
+    ├── conftest.py          # pytest config
+    └── test_basic.py        # Test suite (mirrors cupcake-ts tests)
+```
+
+The Python wrapper follows the same pattern as the TypeScript bindings:
+
+1. **Rust layer** (`src/lib.rs`) — PyO3 `PolicyEngine` class wrapping `cupcake_core::bindings::BindingEngine`
+2. **Python layer** (`python/cupcake/`) — Ergonomic `Cupcake` wrapper with async support via `ThreadPoolExecutor`, error handling, and OPA auto-installation
+
+### How it maps to the TS bindings
+
+| TypeScript (`cupcake-ts`) | Python (`cupcake-py`) |
+|---|---|
+| NAPI-RS (`napi`, `napi-derive`) | PyO3 (`pyo3`) |
+| `src/lib.rs` → `#[napi] PolicyEngine` | `src/lib.rs` → `#[pyclass] PolicyEngine` |
+| `index.ts` → `Cupcake` class | `__init__.py` → `Cupcake` class |
+| `installer.ts` → OPA auto-download | `_installer.py` → OPA auto-download |
+| `evaluateAsync` → libuv threadpool | `evaluate()` → `ThreadPoolExecutor` |
+| `evaluateSync` → blocks event loop | `evaluate_sync()` → blocks thread |
+
+## License
+
+MIT

--- a/cupcake-py/README.md
+++ b/cupcake-py/README.md
@@ -6,11 +6,38 @@ Built with [PyO3](https://pyo3.rs) + [maturin](https://www.maturin.rs), wrapping
 
 ## Installation
 
+> **Note:** `cupcake` is not yet published to PyPI. Install from source using one of the methods below.
+
+### From source (maturin)
+
 ```bash
-pip install cupcake
+# Clone the repo
+git clone https://github.com/eqtylab/cupcake.git
+cd cupcake/cupcake-py
+
+# Build and install in one step (editable/dev mode)
+pip install maturin
+maturin develop --release
+
+# Or build a wheel and install it
+maturin build --release
+pip install ../target/wheels/cupcake-*.whl
 ```
 
-Or build from source (see [Development](#development) below).
+### From source (Nix)
+
+```bash
+nix build .#cupcake-py
+```
+
+### Using just
+
+```bash
+just build-python        # Build bindings
+just build-python-wheel  # Build distributable wheel
+```
+
+See [Development](#development) for full prerequisites and details.
 
 ## Quick Start
 

--- a/cupcake-py/README.md
+++ b/cupcake-py/README.md
@@ -251,7 +251,3 @@ The Python wrapper follows the same pattern as the TypeScript bindings:
 | `installer.ts` → OPA auto-download | `_installer.py` → OPA auto-download |
 | `evaluateAsync` → libuv threadpool | `evaluate()` → `ThreadPoolExecutor` |
 | `evaluateSync` → blocks event loop | `evaluate_sync()` → blocks thread |
-
-## License
-
-MIT

--- a/cupcake-py/pyproject.toml
+++ b/cupcake-py/pyproject.toml
@@ -1,0 +1,47 @@
+[project]
+name = "cupcake"
+version = "0.2.0"
+description = "Python bindings for the Cupcake policy engine — governance and safety for AI coding agents"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+keywords = ["policy", "governance", "opa", "rego", "ai-safety", "agent", "automation"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Rust",
+    "Topic :: Security",
+    "Topic :: Software Development :: Libraries",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/eqtylab/cupcake"
+Repository = "https://github.com/eqtylab/cupcake"
+Documentation = "https://cupcake.eqtylab.io"
+
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[tool.maturin]
+# Build the native extension module as cupcake._native
+module-name = "cupcake._native"
+# Python source is in python/ directory
+python-source = "python"
+# Features to pass to cargo
+features = ["pyo3/extension-module"]
+# Include the Python package files
+include = ["python/cupcake/**/*.py", "python/cupcake/py.typed"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/cupcake-py/python/cupcake/__init__.py
+++ b/cupcake-py/python/cupcake/__init__.py
@@ -1,0 +1,392 @@
+"""Cupcake — Policy enforcement for AI agents and automation tools.
+
+Python bindings for the Cupcake policy engine, enabling custom applications
+to embed OPA/Rego policy evaluation for governance and safety.
+
+Usage::
+
+    from cupcake import Cupcake
+
+    cupcake = Cupcake()
+    await cupcake.init(".cupcake")
+
+    decision = await cupcake.evaluate({
+        "kind": "shell",
+        "command": "rm -rf /",
+        "user": "agent",
+    })
+
+    if decision["decision"] == "Deny":
+        raise RuntimeError(f"Blocked: {decision['reason']}")
+
+Both class-based (multiple policy sets) and module-level (singleton) APIs
+are provided, mirroring the TypeScript bindings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from enum import Enum
+from typing import Any, Literal
+
+logger = logging.getLogger("cupcake")
+
+__all__ = [
+    "Cupcake",
+    "CupcakeError",
+    "Decision",
+    "HookEvent",
+    "Severity",
+    "init",
+    "init_sync",
+    "evaluate",
+    "evaluate_sync",
+    "version",
+    "is_ready",
+]
+
+# Type aliases
+HookEvent = dict[str, Any]
+"""Hook event input — a generic dict your application defines.
+
+Cupcake doesn't enforce a specific event schema for embedded use.
+Your policies evaluate whatever structure you provide.
+
+Example::
+
+    event: HookEvent = {
+        "kind": "tool_use",
+        "tool": "database_query",
+        "query": "DELETE FROM users",
+        "user_id": "agent-123",
+    }
+"""
+
+
+class Severity(str, Enum):
+    """Severity levels for policy decisions."""
+
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
+# Decision is a TypedDict-like structure returned as a plain dict.
+# We keep it as dict[str, Any] for flexibility (policies can add fields).
+Decision = dict[str, Any]
+"""Policy decision returned from evaluation.
+
+Standard fields::
+
+    {
+        "decision": "Allow" | "Deny" | "Halt" | "Ask" | "Modify",
+        "reason": "...",           # Human-readable reason
+        "context": ["..."],        # Guidance (for Allow)
+        "severity": "HIGH",        # LOW / MEDIUM / HIGH / CRITICAL
+        "rule_id": "SEC-001",      # Rule that triggered
+        "updated_input": {...},    # Modified input (for Modify)
+    }
+"""
+
+# Shared thread pool for async operations (mirrors libuv threadpool in TS)
+_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="cupcake")
+
+
+class CupcakeError(Exception):
+    """Error raised by the Cupcake engine.
+
+    Attributes:
+        code: Machine-readable error code.
+        cause: Original exception, if any.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        code: str,
+        cause: BaseException | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.cause = cause
+        if cause is not None:
+            self.__cause__ = cause
+
+
+class Cupcake:
+    """Main Cupcake class for policy evaluation.
+
+    Wraps the native Rust engine and provides a Python-friendly API.
+    Create multiple instances to evaluate against different policy sets.
+
+    Example::
+
+        # Instance-based API (recommended for multiple policy sets)
+        production = Cupcake()
+        await production.init("./policies/production")
+
+        staging = Cupcake()
+        await staging.init("./policies/staging")
+
+        await production.evaluate(event)
+        await staging.evaluate(event)
+    """
+
+    def __init__(self) -> None:
+        self._engine: Any | None = None
+        self._initialized: bool = False
+
+    async def init(
+        self,
+        path: str = ".cupcake",
+        harness: Literal["claude", "cursor", "factory", "opencode"] = "claude",
+    ) -> None:
+        """Initialize the Cupcake engine.
+
+        This method:
+        1. Ensures the OPA binary is installed (auto-downloads if needed).
+        2. Loads and compiles policies from the specified directory.
+        3. Initializes the WASM runtime.
+
+        The heavy lifting runs in a thread pool to avoid blocking the
+        event loop.
+
+        Args:
+            path: Path to project directory or ``.cupcake`` folder.
+            harness: Harness type for policy namespace.
+
+        Raises:
+            CupcakeError: If already initialized or initialization fails.
+        """
+        if self._initialized:
+            raise CupcakeError("Cupcake already initialized", "ALREADY_INITIALIZED")
+
+        try:
+            from ._installer import ensure_opa_installed
+
+            await ensure_opa_installed()
+
+            loop = asyncio.get_running_loop()
+            engine = await loop.run_in_executor(
+                _executor, _create_engine, path, harness
+            )
+            self._engine = engine
+            self._initialized = True
+        except CupcakeError:
+            raise
+        except Exception as exc:
+            raise CupcakeError(
+                f"Failed to initialize Cupcake: {exc}", "INIT_FAILED", exc
+            ) from exc
+
+    def init_sync(
+        self,
+        path: str = ".cupcake",
+        harness: Literal["claude", "cursor", "factory", "opencode"] = "claude",
+    ) -> None:
+        """Initialize the Cupcake engine synchronously (blocks the thread).
+
+        Warning:
+            This method blocks the calling thread during initialization.
+            Only use in CLI scripts or top-level startup code before an
+            event loop starts.  For async applications, use :meth:`init`.
+
+        Args:
+            path: Path to project directory or ``.cupcake`` folder.
+            harness: Harness type for policy namespace.
+
+        Raises:
+            CupcakeError: If already initialized or initialization fails.
+        """
+        if self._initialized:
+            raise CupcakeError("Cupcake already initialized", "ALREADY_INITIALIZED")
+
+        try:
+            from ._installer import ensure_opa_installed_sync
+
+            ensure_opa_installed_sync()
+
+            self._engine = _create_engine(path, harness)
+            self._initialized = True
+        except CupcakeError:
+            raise
+        except Exception as exc:
+            raise CupcakeError(
+                f"Failed to initialize Cupcake: {exc}", "INIT_FAILED", exc
+            ) from exc
+
+    async def evaluate(self, event: HookEvent) -> Decision:
+        """Evaluate a hook event asynchronously (recommended, non-blocking).
+
+        Runs policy evaluation in a thread pool so the event loop stays
+        responsive.
+
+        Args:
+            event: Hook event dict (your application defines the structure).
+
+        Returns:
+            Policy decision dict.
+
+        Raises:
+            CupcakeError: If not initialized or evaluation fails.
+        """
+        if self._engine is None:
+            raise CupcakeError(
+                "Cupcake not initialized. Call init() first.", "NOT_INITIALIZED"
+            )
+
+        try:
+            input_json = json.dumps(event)
+            loop = asyncio.get_running_loop()
+            result_json = await loop.run_in_executor(
+                _executor, self._engine.evaluate, input_json
+            )
+            return json.loads(result_json)
+        except CupcakeError:
+            raise
+        except Exception as exc:
+            raise CupcakeError(
+                f"Policy evaluation failed: {exc}", "EVALUATION_FAILED", exc
+            ) from exc
+
+    def evaluate_sync(self, event: HookEvent) -> Decision:
+        """Evaluate a hook event synchronously (blocks the thread).
+
+        Warning:
+            This method blocks the calling thread until evaluation
+            completes.  For async applications, use :meth:`evaluate`.
+
+        Args:
+            event: Hook event dict.
+
+        Returns:
+            Policy decision dict.
+
+        Raises:
+            CupcakeError: If not initialized or evaluation fails.
+        """
+        if self._engine is None:
+            raise CupcakeError(
+                "Cupcake not initialized. Call init_sync() first.",
+                "NOT_INITIALIZED",
+            )
+
+        try:
+            input_json = json.dumps(event)
+            result_json = self._engine.evaluate(input_json)
+            return json.loads(result_json)
+        except CupcakeError:
+            raise
+        except Exception as exc:
+            raise CupcakeError(
+                f"Policy evaluation failed: {exc}", "EVALUATION_FAILED", exc
+            ) from exc
+
+    @property
+    def version(self) -> str:
+        """The Cupcake engine version string."""
+        if self._engine is None:
+            raise CupcakeError("Cupcake not initialized", "NOT_INITIALIZED")
+        return self._engine.version()
+
+    @property
+    def is_ready(self) -> bool:
+        """Whether the engine is ready to evaluate policies."""
+        if self._engine is None:
+            return False
+        return self._engine.is_ready()
+
+    def __repr__(self) -> str:
+        if self._initialized:
+            return f"Cupcake(version={self.version!r}, ready={self.is_ready})"
+        return "Cupcake(initialized=False)"
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton API (convenience, mirrors TS module functions)
+# ---------------------------------------------------------------------------
+
+_default_instance: Cupcake | None = None
+
+
+async def init(
+    path: str = ".cupcake",
+    harness: Literal["claude", "cursor", "factory", "opencode"] = "claude",
+) -> None:
+    """Initialize the default Cupcake instance.
+
+    Convenience function for the module-level API.  For multiple policy
+    sets, use the class-based API instead.
+
+    Example::
+
+        import cupcake
+        await cupcake.init(".cupcake")
+        decision = await cupcake.evaluate(event)
+    """
+    global _default_instance  # noqa: PLW0603
+    _default_instance = Cupcake()
+    await _default_instance.init(path, harness)
+
+
+def init_sync(
+    path: str = ".cupcake",
+    harness: Literal["claude", "cursor", "factory", "opencode"] = "claude",
+) -> None:
+    """Initialize the default Cupcake instance synchronously.
+
+    Warning:
+        Blocks the calling thread.  Use :func:`init` for async code.
+    """
+    global _default_instance  # noqa: PLW0603
+    _default_instance = Cupcake()
+    _default_instance.init_sync(path, harness)
+
+
+async def evaluate(event: HookEvent) -> Decision:
+    """Evaluate an event using the default instance (async, non-blocking)."""
+    if _default_instance is None:
+        raise CupcakeError(
+            "Cupcake not initialized. Call init() first.", "NOT_INITIALIZED"
+        )
+    return await _default_instance.evaluate(event)
+
+
+def evaluate_sync(event: HookEvent) -> Decision:
+    """Evaluate an event using the default instance (sync, blocks thread)."""
+    if _default_instance is None:
+        raise CupcakeError(
+            "Cupcake not initialized. Call init_sync() first.",
+            "NOT_INITIALIZED",
+        )
+    return _default_instance.evaluate_sync(event)
+
+
+def version() -> str:
+    """Get the Cupcake engine version from the default instance."""
+    if _default_instance is None:
+        raise CupcakeError("Cupcake not initialized", "NOT_INITIALIZED")
+    return _default_instance.version
+
+
+def is_ready() -> bool:
+    """Check if the default instance is ready."""
+    if _default_instance is None:
+        return False
+    return _default_instance.is_ready
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_engine(path: str, harness: str) -> Any:
+    """Create a native PolicyEngine (called from thread pool)."""
+    from ._native import PolicyEngine
+
+    return PolicyEngine(path, harness)

--- a/cupcake-py/python/cupcake/_installer.py
+++ b/cupcake-py/python/cupcake/_installer.py
@@ -1,0 +1,226 @@
+"""OPA binary installer for Cupcake Python bindings.
+
+Handles automatic download and SHA-256 verification of the OPA binary
+required for policy compilation.  This is a direct port of
+``cupcake-ts/installer.ts``.
+
+OPA Version: v0.70.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+import platform
+import shutil
+import stat
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from urllib.request import urlopen, Request
+
+logger = logging.getLogger("cupcake.installer")
+
+OPA_VERSION = "v0.70.0"
+_OPA_BASE_URL = f"https://github.com/open-policy-agent/opa/releases/download/{OPA_VERSION}"
+
+# Platform-specific binary mapping with SHA-256 checksums.
+# Keys are ``{sys.platform}-{machine}`` after normalisation.
+_OPA_BINARIES: dict[str, dict[str, str | float]] = {
+    "darwin-x86_64": {
+        "binary": "opa_darwin_amd64",
+        "sha256": "51da8fa6ce4ac9b963d4babbd78714e98880b20e74f30a3f45a96334e12830bd",
+        "size_mb": 67.3,
+    },
+    "darwin-arm64": {
+        "binary": "opa_darwin_arm64_static",
+        "sha256": "fe2a14b6ba7f587caeb62ef93ef62d1e713776a6e470f4e87326468a8ecfbfbd",
+        "size_mb": 43.8,
+    },
+    "linux-x86_64": {
+        "binary": "opa_linux_amd64",
+        "sha256": "7426bf5504049d7444f9ee9a1d47a64261842f38f5308903ef6b76ba90250b5a",
+        "size_mb": 67.1,
+    },
+    "linux-aarch64": {
+        "binary": "opa_linux_arm64_static",
+        "sha256": "a81af8cd767f1870e9e23b8ed0ad8f40b24e5c0a64c5768c75d5c292aaa81e54",
+        "size_mb": 43.2,
+    },
+    "win32-x86_64": {
+        "binary": "opa_windows_amd64.exe",
+        "sha256": "205f87d0fd1e2673c3a6f9caf9d9655290e478a93eeb3ef9f211acdaa214a9ca",
+        "size_mb": 98.7,
+    },
+}
+
+_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="cupcake-opa")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+async def ensure_opa_installed() -> Path:
+    """Ensure OPA is installed and return its path (async).
+
+    Uses an existing OPA if found, otherwise downloads it.
+    """
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_executor, ensure_opa_installed_sync)
+
+
+def ensure_opa_installed_sync() -> Path:
+    """Ensure OPA is installed and return its path (blocking)."""
+    existing = _find_opa()
+    if existing is not None:
+        return existing
+    return download_opa()
+
+
+def download_opa(*, force: bool = False) -> Path:
+    """Download and verify the OPA binary for the current platform.
+
+    Args:
+        force: Re-download even if the binary already exists.
+
+    Returns:
+        Path to the OPA executable.
+    """
+    key = _platform_key()
+    if key not in _OPA_BINARIES:
+        supported = ", ".join(sorted(_OPA_BINARIES))
+        raise RuntimeError(
+            f"Unsupported platform: {key}\nSupported platforms: {supported}"
+        )
+
+    info = _OPA_BINARIES[key]
+    binary_name: str = info["binary"]  # type: ignore[assignment]
+    expected_sha256: str = info["sha256"]  # type: ignore[assignment]
+    size_mb: float = info["size_mb"]  # type: ignore[assignment]
+
+    cache_dir = _cache_dir()
+    local_name = f"opa-{OPA_VERSION}"
+    if sys.platform == "win32":
+        local_name += ".exe"
+    local_path = cache_dir / local_name
+
+    # Check if already downloaded and valid
+    if local_path.exists() and not force:
+        logger.info("Verifying existing OPA binary at %s ...", local_path)
+        if _verify_checksum(local_path, expected_sha256):
+            logger.info("Checksum verified.")
+            return local_path
+        logger.warning("Checksum mismatch — re-downloading.")
+        local_path.unlink()
+
+    url = f"{_OPA_BASE_URL}/{binary_name}"
+    tmp_path = local_path.with_suffix(".tmp")
+
+    try:
+        _download(url, tmp_path, size_mb)
+
+        logger.info("Verifying checksum ...")
+        if not _verify_checksum(tmp_path, expected_sha256):
+            raise RuntimeError(
+                f"SHA-256 verification failed for {binary_name}.\n"
+                "This could indicate a corrupted download or security issue."
+            )
+
+        tmp_path.rename(local_path)
+        _make_executable(local_path)
+
+        logger.info("OPA %s installed at %s", OPA_VERSION, local_path)
+        return local_path
+    except BaseException:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _platform_key() -> str:
+    """Return a normalised ``platform-arch`` string."""
+    plat = sys.platform  # linux, darwin, win32
+    machine = platform.machine()  # x86_64, arm64, aarch64, AMD64
+
+    arch_map: dict[str, str] = {
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+        "arm64": "arm64",
+        "aarch64": "aarch64",
+    }
+    arch = arch_map.get(machine.lower())
+    if arch is None:
+        raise RuntimeError(f"Unsupported architecture: {machine}")
+
+    return f"{plat}-{arch}"
+
+
+def _cache_dir() -> Path:
+    """Return (and create) the OPA cache directory."""
+    if sys.platform == "win32":
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    else:
+        base = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+
+    cache = base / "cupcake" / "bin"
+    cache.mkdir(parents=True, exist_ok=True)
+    return cache
+
+
+def _verify_checksum(path: Path, expected: str) -> bool:
+    sha = hashlib.sha256()
+    with open(path, "rb") as fh:
+        while chunk := fh.read(1 << 16):
+            sha.update(chunk)
+    return sha.hexdigest() == expected
+
+
+def _download(url: str, dest: Path, size_mb: float) -> None:
+    logger.info("Downloading OPA %s (%.1f MB) ...", OPA_VERSION, size_mb)
+
+    req = Request(url, headers={"User-Agent": "cupcake-py"})
+    with urlopen(req) as resp, open(dest, "wb") as fh:  # noqa: S310
+        total = int(resp.headers.get("Content-Length", 0))
+        downloaded = 0
+        while chunk := resp.read(1 << 16):
+            fh.write(chunk)
+            downloaded += len(chunk)
+            if total > 0:
+                pct = downloaded / total * 100
+                print(f"\rProgress: {pct:.1f}%", end="", flush=True)
+
+    print()  # newline after progress
+    logger.info("Download complete.")
+
+
+def _make_executable(path: Path) -> None:
+    if sys.platform != "win32":
+        path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _find_opa() -> Path | None:
+    """Find an existing OPA binary (cache first, then PATH)."""
+    # Check cache
+    cache = _cache_dir()
+    local_name = f"opa-{OPA_VERSION}"
+    if sys.platform == "win32":
+        local_name += ".exe"
+    cached = cache / local_name
+    if cached.exists():
+        return cached
+
+    # Check system PATH
+    opa_cmd = "opa.exe" if sys.platform == "win32" else "opa"
+    system_opa = shutil.which(opa_cmd)
+    if system_opa is not None:
+        return Path(system_opa)
+
+    return None

--- a/cupcake-py/python/cupcake/_native.pyi
+++ b/cupcake-py/python/cupcake/_native.pyi
@@ -1,0 +1,45 @@
+"""Type stubs for the native Rust extension module.
+
+These stubs provide type information for ``cupcake._native``, the
+PyO3-compiled extension.  They are used by type checkers (mypy, pyright)
+and IDEs for autocompletion.
+"""
+
+class PolicyEngine:
+    """Native policy engine wrapping the Cupcake Rust core.
+
+    Args:
+        path: Path to project directory or ``.cupcake`` folder.
+        harness: Harness type (``"claude"``, ``"cursor"``, ``"factory"``,
+                 ``"opencode"``).  Defaults to ``"claude"``.
+
+    Raises:
+        RuntimeError: If initialization fails.
+    """
+
+    def __init__(self, path: str, harness: str | None = None) -> None: ...
+
+    def evaluate(self, input_json: str) -> str:
+        """Evaluate a hook event.
+
+        Args:
+            input_json: JSON string containing the hook event.
+
+        Returns:
+            JSON string with the policy decision.
+
+        Raises:
+            ValueError: If ``input_json`` is not valid JSON.
+            RuntimeError: If evaluation fails.
+        """
+        ...
+
+    def version(self) -> str:
+        """Return the Cupcake engine version string."""
+        ...
+
+    def is_ready(self) -> bool:
+        """Return whether the engine is ready to evaluate policies."""
+        ...
+
+    def __repr__(self) -> str: ...

--- a/cupcake-py/src/lib.rs
+++ b/cupcake-py/src/lib.rs
@@ -1,0 +1,106 @@
+//! Python bindings for the Cupcake policy engine.
+//!
+//! This module provides PyO3 bindings that wrap the core BindingEngine,
+//! exposing a Python-friendly API for policy evaluation.
+//!
+//! The design mirrors `cupcake-ts` (NAPI-RS bindings for Node.js):
+//! - `PolicyEngine` class wraps `BindingEngine` from `cupcake-core`
+//! - JSON in/out for maximum compatibility
+//! - Both sync and async-compatible evaluation
+//! - Thread-safe (`Send + Sync`) for use with Python's `ThreadPoolExecutor`
+
+use cupcake_core::bindings::BindingEngine;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+
+/// Native policy engine for evaluating Cupcake policies.
+///
+/// This class wraps the Rust `BindingEngine` and is intended to be used
+/// through the pure-Python `cupcake.Cupcake` wrapper, though it can be
+/// used directly for advanced use cases.
+///
+/// Thread Safety:
+///   The engine is `Send + Sync` and can be shared across Python threads
+///   (e.g. via `concurrent.futures.ThreadPoolExecutor`).
+///
+/// Example (direct usage)::
+///
+///     from cupcake._native import PolicyEngine
+///     engine = PolicyEngine(".cupcake", "claude")
+///     result_json = engine.evaluate('{"tool_name": "Bash", "command": "ls"}')
+#[pyclass(name = "PolicyEngine")]
+pub struct PyPolicyEngine {
+    inner: BindingEngine,
+}
+
+#[pymethods]
+impl PyPolicyEngine {
+    /// Create a new PolicyEngine instance.
+    ///
+    /// Args:
+    ///     path: Path to project directory or .cupcake folder.
+    ///     harness: Harness type (``"claude"``, ``"cursor"``, ``"factory"``,
+    ///              ``"opencode"``). Defaults to ``"claude"``.
+    ///
+    /// Raises:
+    ///     RuntimeError: If the path doesn't exist, OPA binary is missing,
+    ///                   or policy compilation fails.
+    #[new]
+    #[pyo3(signature = (path, harness=None))]
+    fn new(path: String, harness: Option<String>) -> PyResult<Self> {
+        let harness_str = harness.as_deref().unwrap_or("claude");
+        let engine = BindingEngine::new(&path, harness_str).map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to initialize engine: {e}"))
+        })?;
+        Ok(Self { inner: engine })
+    }
+
+    /// Evaluate a hook event against loaded policies.
+    ///
+    /// This method blocks the calling thread until evaluation completes.
+    /// For async usage, run this in a thread pool via the Python wrapper's
+    /// ``evaluate()`` async method.
+    ///
+    /// Args:
+    ///     input_json: JSON string containing the hook event.
+    ///
+    /// Returns:
+    ///     JSON string with the policy decision.
+    ///
+    /// Raises:
+    ///     ValueError: If ``input_json`` is not valid JSON.
+    ///     RuntimeError: If policy evaluation fails.
+    fn evaluate(&self, input_json: &str) -> PyResult<String> {
+        self.inner.evaluate_sync(input_json).map_err(|e| {
+            if e.contains("Invalid input JSON") {
+                PyValueError::new_err(e)
+            } else {
+                PyRuntimeError::new_err(e)
+            }
+        })
+    }
+
+    /// Return the Cupcake engine version string.
+    fn version(&self) -> String {
+        self.inner.version()
+    }
+
+    /// Return whether the engine is ready to evaluate policies.
+    fn is_ready(&self) -> bool {
+        self.inner.is_ready()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("PolicyEngine(version={:?}, ready={})", self.inner.version(), self.inner.is_ready())
+    }
+}
+
+/// cupcake._native — low-level Rust bindings for the Cupcake policy engine.
+///
+/// This module is not intended for direct use. Import ``cupcake`` instead.
+#[pymodule]
+#[pyo3(name = "_native")]
+fn cupcake_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyPolicyEngine>()?;
+    Ok(())
+}

--- a/cupcake-py/src/lib.rs
+++ b/cupcake-py/src/lib.rs
@@ -49,9 +49,8 @@ impl PyPolicyEngine {
     #[pyo3(signature = (path, harness=None))]
     fn new(path: String, harness: Option<String>) -> PyResult<Self> {
         let harness_str = harness.as_deref().unwrap_or("claude");
-        let engine = BindingEngine::new(&path, harness_str).map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to initialize engine: {e}"))
-        })?;
+        let engine = BindingEngine::new(&path, harness_str)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to initialize engine: {e}")))?;
         Ok(Self { inner: engine })
     }
 
@@ -91,7 +90,11 @@ impl PyPolicyEngine {
     }
 
     fn __repr__(&self) -> String {
-        format!("PolicyEngine(version={:?}, ready={})", self.inner.version(), self.inner.is_ready())
+        format!(
+            "PolicyEngine(version={:?}, ready={})",
+            self.inner.version(),
+            self.inner.is_ready()
+        )
     }
 }
 

--- a/cupcake-py/tests/conftest.py
+++ b/cupcake-py/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest configuration for cupcake-py tests."""
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def anyio_backend():
+    return "asyncio"

--- a/cupcake-py/tests/test_basic.py
+++ b/cupcake-py/tests/test_basic.py
@@ -1,0 +1,356 @@
+"""Basic tests for Cupcake Python bindings.
+
+Mirrors ``cupcake-ts/__test__/basic.test.ts``.
+
+Tests are structured in two tiers:
+
+- **Engine tests** require OPA with WASM compilation support.  OPA's static
+  ARM64 builds lack WASM, so these are skipped on platforms where policy
+  compilation is unavailable.  They always pass on x86_64 CI.
+- **Pure-Python tests** (error classes, repr, not-initialized guards) run
+  everywhere the native module is installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cupcake import Cupcake, CupcakeError
+
+# ---------------------------------------------------------------------------
+# External test-fixtures (shared with cupcake-ts, may not exist)
+# ---------------------------------------------------------------------------
+
+TEST_CUPCAKE_DIR = str(
+    Path(__file__).resolve().parent.parent.parent
+    / "test-fixtures"
+    / ".cupcake"
+)
+
+_HAS_FIXTURES = os.path.isdir(TEST_CUPCAKE_DIR)
+needs_fixtures = pytest.mark.skipif(
+    not _HAS_FIXTURES, reason=f"test fixtures not found at {TEST_CUPCAKE_DIR}"
+)
+
+# ---------------------------------------------------------------------------
+# Skip everything if the native module isn't built
+# ---------------------------------------------------------------------------
+
+try:
+    from cupcake._native import PolicyEngine as _PE  # noqa: F401
+    _HAS_NATIVE = True
+except ImportError:
+    _HAS_NATIVE = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_NATIVE, reason="cupcake._native not built (run `maturin develop` first)"
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal inline fixture — mirrors cupcake-core/tests/common/mod.rs
+# The system evaluate.rego uses walk() which requires OPA WASM support.
+# ---------------------------------------------------------------------------
+
+_MINIMAL_POLICY_REGO = """\
+# METADATA
+# scope: package
+# custom:
+#   routing:
+#     required_events: ["UserPromptSubmit"]
+package cupcake.policies.minimal
+
+import rego.v1
+
+deny contains decision if {
+    input.test_condition == "never_match_12345"
+    decision := {
+        "reason": "Test policy that never triggers",
+        "severity": "LOW",
+        "rule_id": "TEST-001"
+    }
+}
+"""
+
+_SYSTEM_EVALUATE_REGO = """\
+package cupcake.system
+
+import rego.v1
+
+# METADATA
+# scope: document
+# title: System Aggregation Entrypoint
+# custom:
+#   entrypoint: true
+#   routing:
+#     required_events: []
+#     required_tools: []
+
+evaluate := decision_set if {
+    decision_set := {
+        "halts": collect_verbs("halt"),
+        "denials": collect_verbs("deny"),
+        "blocks": collect_verbs("block"),
+        "asks": collect_verbs("ask"),
+        "modifications": collect_verbs("modify"),
+        "add_context": collect_verbs("add_context")
+    }
+}
+
+collect_verbs(verb_name) := result if {
+    verb_sets := [value |
+        walk(data.cupcake.policies, [path, value])
+        path[count(path) - 1] == verb_name
+    ]
+    all_decisions := [decision |
+        some verb_set in verb_sets
+        some decision in verb_set
+    ]
+    result := all_decisions
+}
+
+default collect_verbs(_) := []
+"""
+
+
+@pytest.fixture(scope="session")
+def tmp_cupcake_dir() -> str:
+    """Create a minimal .cupcake project (same layout as Rust integration tests)."""
+    with tempfile.TemporaryDirectory(prefix="cupcake-pytest-") as tmp:
+        root = Path(tmp)
+        cupcake = root / ".cupcake"
+        harness_dir = cupcake / "policies" / "claude"
+        system_dir = harness_dir / "system"
+        signals_dir = cupcake / "signals"
+        system_dir.mkdir(parents=True)
+        signals_dir.mkdir(parents=True)
+        (cupcake / "rulebook.yml").write_text("signals: {}\nbuiltins: {}")
+        (harness_dir / "minimal.rego").write_text(_MINIMAL_POLICY_REGO)
+        (system_dir / "evaluate.rego").write_text(_SYSTEM_EVALUATE_REGO)
+        yield str(root)
+
+
+def _can_init_engine(path: str) -> bool:
+    """Try to create an engine — returns False if OPA WASM compilation unavailable."""
+    try:
+        from cupcake._native import PolicyEngine
+        PolicyEngine(path, "claude")
+        return True
+    except RuntimeError:
+        return False
+
+
+@pytest.fixture(scope="session")
+def engine_available(tmp_cupcake_dir: str) -> bool:
+    return _can_init_engine(tmp_cupcake_dir)
+
+
+def _skip_unless_engine(engine_available: bool) -> None:
+    if not engine_available:
+        pytest.skip(
+            "OPA WASM compilation unavailable on this platform "
+            "(ARM64 static builds lack WASM support)"
+        )
+
+
+# ---- Initialization ---------------------------------------------------------
+
+
+class TestInitialization:
+    async def test_init_async(self, tmp_cupcake_dir: str, engine_available: bool) -> None:
+        _skip_unless_engine(engine_available)
+        cupcake = Cupcake()
+        await cupcake.init(tmp_cupcake_dir)
+        assert cupcake.is_ready is True
+        assert cupcake.version
+
+    def test_init_sync(self, tmp_cupcake_dir: str, engine_available: bool) -> None:
+        _skip_unless_engine(engine_available)
+        cupcake = Cupcake()
+        cupcake.init_sync(tmp_cupcake_dir)
+        assert cupcake.is_ready is True
+
+    async def test_double_init_raises(self, tmp_cupcake_dir: str, engine_available: bool) -> None:
+        _skip_unless_engine(engine_available)
+        cupcake = Cupcake()
+        await cupcake.init(tmp_cupcake_dir)
+        with pytest.raises(CupcakeError, match="already initialized"):
+            await cupcake.init(tmp_cupcake_dir)
+
+    async def test_invalid_path_raises(self) -> None:
+        cupcake = Cupcake()
+        with pytest.raises(CupcakeError):
+            await cupcake.init("/nonexistent/path")
+
+    def test_not_initialized_repr(self) -> None:
+        cupcake = Cupcake()
+        assert "initialized=False" in repr(cupcake)
+
+    def test_initialized_repr(self, tmp_cupcake_dir: str, engine_available: bool) -> None:
+        _skip_unless_engine(engine_available)
+        cupcake = Cupcake()
+        cupcake.init_sync(tmp_cupcake_dir)
+        r = repr(cupcake)
+        assert "version=" in r
+        assert "ready=True" in r
+
+
+# ---- Evaluation --------------------------------------------------------------
+
+
+class TestEvaluation:
+    @pytest.fixture(autouse=True)
+    async def _init_cupcake(self, tmp_cupcake_dir: str, engine_available: bool) -> None:
+        _skip_unless_engine(engine_available)
+        self.cupcake = Cupcake()
+        await self.cupcake.init(tmp_cupcake_dir)
+
+    async def test_evaluate_async(self) -> None:
+        event = {
+            "hookEventName": "PreToolUse",
+            "tool_name": "Bash",
+            "command": "ls",
+            "args": ["-la"],
+        }
+        decision = await self.cupcake.evaluate(event)
+        assert isinstance(decision, dict)
+        assert any(
+            k in decision for k in ("Allow", "Deny", "Halt", "Ask", "Modify")
+        )
+
+    def test_evaluate_sync(self) -> None:
+        event = {
+            "hookEventName": "PreToolUse",
+            "tool_name": "Bash",
+            "command": "ls",
+            "args": ["-la"],
+        }
+        decision = self.cupcake.evaluate_sync(event)
+        assert isinstance(decision, dict)
+        assert any(
+            k in decision for k in ("Allow", "Deny", "Halt", "Ask", "Modify")
+        )
+
+    async def test_custom_event(self) -> None:
+        event = {
+            "hookEventName": "UserPromptSubmit",
+            "prompt": "test prompt",
+            "user": "test-user",
+        }
+        decision = await self.cupcake.evaluate(event)
+        assert isinstance(decision, dict)
+
+    async def test_concurrent_evaluations(self) -> None:
+        events = [
+            {
+                "hookEventName": "PreToolUse",
+                "tool_name": "Bash",
+                "command": "echo",
+                "args": [f"test-{i}"],
+            }
+            for i in range(10)
+        ]
+        decisions = await asyncio.gather(
+            *(self.cupcake.evaluate(e) for e in events)
+        )
+        assert len(decisions) == 10
+        for d in decisions:
+            assert isinstance(d, dict)
+
+
+class TestEvaluationNoInit:
+    async def test_evaluate_before_init_raises(self) -> None:
+        uninit = Cupcake()
+        with pytest.raises(CupcakeError, match="not initialized"):
+            await uninit.evaluate({"hookEventName": "PreToolUse"})
+
+
+# ---- Module-level API --------------------------------------------------------
+
+
+class TestModuleAPI:
+    async def test_module_level_functions(self, tmp_cupcake_dir: str, engine_available: bool) -> None:
+        _skip_unless_engine(engine_available)
+        import cupcake
+
+        await cupcake.init(tmp_cupcake_dir)
+        assert cupcake.is_ready() is True
+        assert cupcake.version()
+
+        decision = await cupcake.evaluate({
+            "hookEventName": "PreToolUse",
+            "tool_name": "Bash",
+            "command": "test",
+        })
+        assert isinstance(decision, dict)
+
+
+# ---- Evaluation with shared test-fixtures (optional) -------------------------
+
+
+@needs_fixtures
+class TestExternalFixtures:
+    @pytest.fixture(autouse=True)
+    async def _init_cupcake(self, engine_available: bool) -> None:
+        _skip_unless_engine(engine_available)
+        self.cupcake = Cupcake()
+        await self.cupcake.init(TEST_CUPCAKE_DIR)
+
+    async def test_evaluate_external(self) -> None:
+        decision = await self.cupcake.evaluate({
+            "hookEventName": "PreToolUse",
+            "tool_name": "Bash",
+            "command": "ls -la",
+        })
+        assert isinstance(decision, dict)
+
+
+# ---- Error handling ----------------------------------------------------------
+
+
+class TestErrors:
+    async def test_error_has_code(self) -> None:
+        cupcake = Cupcake()
+        try:
+            await cupcake.init("/invalid/path")
+            pytest.fail("Should have raised CupcakeError")
+        except CupcakeError as exc:
+            assert exc.code
+            assert str(exc)
+
+    def test_cupcake_error_attributes(self) -> None:
+        err = CupcakeError("test message", "TEST_CODE")
+        assert err.code == "TEST_CODE"
+        assert err.cause is None
+        assert str(err) == "test message"
+
+    def test_cupcake_error_with_cause(self) -> None:
+        cause = ValueError("original")
+        err = CupcakeError("wrapped", "WRAP", cause)
+        assert err.cause is cause
+        assert err.__cause__ is cause
+
+
+# ---- Version -----------------------------------------------------------------
+
+
+class TestVersion:
+    async def test_version_string(self, tmp_cupcake_dir: str, engine_available: bool) -> None:
+        _skip_unless_engine(engine_available)
+        cupcake = Cupcake()
+        await cupcake.init(tmp_cupcake_dir)
+        v = cupcake.version
+        assert isinstance(v, str)
+        assert len(v) > 0
+        assert "cupcake" in v.lower()
+
+    def test_version_before_init_raises(self) -> None:
+        cupcake = Cupcake()
+        with pytest.raises(CupcakeError, match="not initialized"):
+            _ = cupcake.version

--- a/flake.nix
+++ b/flake.nix
@@ -27,11 +27,17 @@
 
         craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rust;
 
+        python = pkgs.python312;
+
         shellDeps = [
           rust
         ] ++ (with pkgs; [
           just
           nixpkgs-fmt
+          # Python bindings development
+          python
+          maturin
+          (python.withPackages (ps: with ps; [ pytest pytest-asyncio ]))
         ]);
 
         cupcake-cli =
@@ -73,6 +79,52 @@
 
         packages = {
           inherit cupcake-cli;
+
+          cupcake-py = pkgs.callPackage ({ lib, maturin, python312, cargo, rustc, rustPlatform }:
+            python312.pkgs.buildPythonPackage {
+              pname = "cupcake";
+              version = cupcake-cli.version;
+              pyproject = true;
+
+              src = pkgs.lib.cleanSourceWith {
+                src = ./.;
+                filter =
+                  let
+                    regoFilter = path: _type: builtins.match ".*rego$" path != null;
+                    ymlFilter = path: _type: builtins.match ".*yml$" path != null;
+                    pyFilter = path: _type: builtins.match ".*py$" path != null;
+                    pyiFilter = path: _type: builtins.match ".*pyi$" path != null;
+                    pytypedFilter = path: _type: builtins.match ".*/py\\.typed$" path != null;
+                    mdFilter = path: _type: builtins.match ".*md$" path != null;
+                  in
+                  path: _type:
+                    (regoFilter path _type)
+                    || (ymlFilter path _type)
+                    || (pyFilter path _type)
+                    || (pyiFilter path _type)
+                    || (pytypedFilter path _type)
+                    || (mdFilter path _type)
+                    || (craneLib.filterCargoSources path _type);
+              };
+
+              cargoDeps = rustPlatform.importCargoLock {
+                lockFile = ./Cargo.lock;
+              };
+
+              nativeBuildInputs = [
+                cargo rustc
+                rustPlatform.cargoSetupHook
+                rustPlatform.maturinBuildHook
+              ];
+
+              # The source is the whole workspace; cd into the Python crate
+              # so maturin finds pyproject.toml + Cargo.toml.
+              # Cargo resolves the workspace root (../) and vendor dir automatically.
+              preBuild = "cd cupcake-py";
+
+              pythonImportsCheck = [ "cupcake" ];
+            }
+          ) {};
         };
 
       }));

--- a/justfile
+++ b/justfile
@@ -29,8 +29,8 @@ install: build-cli
 
 # ==================== TEST COMMANDS ====================
 
-# Run ALL tests (Rust + TypeScript)
-test-all: test test-typescript
+# Run ALL tests (Rust + TypeScript + Python)
+test-all: test test-typescript test-python
 
 # Run Rust tests
 # NOTE: Tests use EngineConfig to disable global config discovery, ensuring isolation
@@ -90,6 +90,65 @@ test-typescript:
 
     # Run tests
     npm test
+
+# Run Python tests (auto-builds if needed)
+test-python:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    echo "Running Python tests..."
+    cd cupcake-py
+
+    # Create virtualenv if it doesn't exist
+    if [ ! -d ".venv" ]; then
+        echo "Creating virtualenv..."
+        python3 -m venv .venv
+    fi
+
+    source .venv/bin/activate
+
+    # Install maturin and test deps if needed
+    if ! command -v maturin &> /dev/null; then
+        echo "Installing maturin and test dependencies..."
+        pip install maturin pytest pytest-asyncio
+    fi
+
+    # Build native module
+    echo "Building native module..."
+    maturin develop --release
+
+    # Run tests
+    pytest tests/ -v
+
+# Build Python bindings (development mode)
+build-python:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd cupcake-py
+    if [ ! -d ".venv" ]; then
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip install maturin
+    else
+        source .venv/bin/activate
+    fi
+    maturin develop --release
+    echo "✅ Python bindings built"
+
+# Build Python wheel for distribution
+build-python-wheel:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd cupcake-py
+    if [ ! -d ".venv" ]; then
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip install maturin
+    else
+        source .venv/bin/activate
+    fi
+    maturin build --release
+    echo "✅ Wheel built in target/wheels/"
 
 # Run benchmarks
 bench:
@@ -158,7 +217,8 @@ stats:
     @echo "📊 Cupcake Project Statistics"
     @echo "=============================="
     @echo "Rust files: $(find . -name '*.rs' -not -path './target/*' | wc -l)"
-    @echo "Test files: $(find . -name '*test*.rs' -not -path './target/*' | wc -l)"  
+    @echo "Python files: $(find . -name '*.py' -not -path './.venv/*' -not -path './target/*' -not -path './*/__pycache__/*' | wc -l)"
+    @echo "Test files: $(find . -name '*test*' \( -name '*.rs' -o -name '*.py' \) -not -path './target/*' | wc -l)"
     @echo "Policy files: $(find . -name '*.rego' | wc -l)"
     @echo "Lines of Rust: $(find . -name '*.rs' -not -path './target/*' | xargs wc -l | tail -1)"
 
@@ -175,6 +235,16 @@ install-dev:
     # Rust tools
     rustup component add rustfmt clippy
     cargo install cargo-watch cargo-edit
+
+    # Python tools
+    if command -v python3 &> /dev/null; then
+        echo "Setting up Python bindings dev environment..."
+        cd cupcake-py
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip install maturin pytest pytest-asyncio
+        cd ..
+    fi
 
     echo "✅ Development dependencies installed"
 

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/pqfl1wkz33cww9jz72vjmgcm8xkm0ipa-python3.12-cupcake-0.5.2


### PR DESCRIPTION
This PR is for issue #100 - add python bindings for cupcake. This was done using PyO3 on the Rust side and maturin on the python side.

Claude code ported the TS bindings for cupcake to python and covered them with tests, and generated changes for the flake.nix, justfile and github ci. I tested the flake.nix and justfile changes as well as tested the integration in my python app using rego files in a unit test harness. I can't test the CI changes fully but hopefully they are solid.